### PR TITLE
added 2 eslint rules

### DIFF
--- a/.eslintrc.cjs
+++ b/.eslintrc.cjs
@@ -1,19 +1,21 @@
 module.exports = {
   root: true,
-  plugins: [
-    "@typescript-eslint",
-  ],
+  plugins: ['@typescript-eslint'],
   overrides: [
     {
-      "files": ["*.ts", "*.tsx", "*.js", "*.jsx"],
+      files: ['*.ts', '*.tsx', '*.js', '*.jsx'],
     },
   ],
   extends: [
-    "eslint:recommended",
-    "plugin:@typescript-eslint/eslint-recommended",
-    "plugin:@typescript-eslint/recommended",
+    'eslint:recommended',
+    'plugin:@typescript-eslint/eslint-recommended',
+    'plugin:@typescript-eslint/recommended',
   ],
   env: {
-    node: true
-  }
+    node: true,
+  },
+  rules: {
+    '@typescript-eslint/no-var-requires': 'off',
+    'no-useless-escape': 'off',
+  },
 };


### PR DESCRIPTION
added `no-var-requires` because metro.config.js needs a require statement, and `no-useless-escape` because the it was triggered by some regex in william's route-docs generator in endpoints.controller.js