### PR TITLE
changed bcrypt package

### DIFF
--- a/backend/package.json
+++ b/backend/package.json
@@ -16,7 +16,7 @@
   ],
   "license": "MIT",
   "dependencies": {
-    "bcrypt": "^5.1.0",
+    "bcryptjs": "2.4.3",
     "cors": "^2.8.5",
     "dotenv": "^16.0.3",
     "express": "^5.0.0-beta.1",

--- a/backend/src/utilities/password.utility.js
+++ b/backend/src/utilities/password.utility.js
@@ -1,4 +1,4 @@
-import bcrypt from 'bcrypt';
+import bcrypt from 'bcryptjs';
 
 export async function hashPassword(password) {
   return await bcrypt.hash(password, 10);


### PR DESCRIPTION
The package 'bcrypt' was causing npm errors on installation for me (which assumes prod would too), I switched it to 'bcryptjs' which is a package intended to have better compatibility. It changes nothing in the code. I've seen this error before in another project but it was some C or C++ library dependency I decided not to chase down.