### PR TITLE
Fixed nginx config to perserve linking

### DIFF
--- a/docker/nginx-conf/default.conf
+++ b/docker/nginx-conf/default.conf
@@ -38,8 +38,19 @@ server {
         ssl_stapling_verify on;
         resolver 8.8.8.8;
 
+        gzip on;
+        gzip_types text/html application/javascript application/json text/css;
+
+        root /var/www/html;
+        index index.html;
+
+        location ~* \.(?:jpg|png)$ {
+            expires 1d;
+            add_header Cache-Control "public";
+        }
+
         location / {
-            root /var/www/html;
+            try_files $uri $uri/ $uri.html /index.html;
         }
 
         location /api {
@@ -50,7 +61,4 @@ server {
             add_header Referrer-Policy "no-referrer-when-downgrade" always;
             add_header Content-Security-Policy "default-src * data: 'unsafe-eval' 'unsafe-inline'" always;
         }
-
-        #root /var/www/html;
-        #index index.html index.htm index.nginx-debian.html;
 }


### PR DESCRIPTION
The magic is the try_files which basically defaults the route if a file with that name isn't in the nginx directory and my other branch with the react navigation linking fixes the other half of the problem. I also threw in caching and gzip because it might help performance a bit.